### PR TITLE
fix: strumのderiveのパラメーターに大文字小文字を無視させる

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,7 +32,7 @@ pub struct Args {
 }
 
 #[derive(EnumString, Display, Copy, Clone, Eq, PartialEq, Debug)]
-#[strum(serialize_all = "camelCase")]
+#[strum(ascii_case_insensitive)]
 pub enum ColorPolicy {
     Always,
     Auto,


### PR DESCRIPTION
fix #80